### PR TITLE
Updated docstring for CVMatrix and NaiveCVMatrix

### DIFF
--- a/cvmatrix/__init__.py
+++ b/cvmatrix/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "3.0.0"
+__version__ = "3.0.0.post1"

--- a/cvmatrix/cvmatrix.py
+++ b/cvmatrix/cvmatrix.py
@@ -53,7 +53,7 @@ class CVMatrix:
     scale_Y : bool, optional, default=True
         Whether to scale `Y` before computation of
         :math:`\mathbf{X}^{\mathbf{T}}\mathbf{W}\mathbf{Y}` by dividing each row with
-        the row of `X`'s column-wise weighted standard deviations. The row of
+        the row of `Y`'s column-wise weighted standard deviations. The row of
         column-wise weighted standard deviations is computed on the training set for
         each fold to avoid data leakage. This parameter is ignored if `Y` is `None`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cvmatrix"
-version = "3.0.0"
+version = "3.0.0.post1"
 description = "Fast computation of possibly weighted and possibly centered/scaled training set kernel matrices in a cross-validation setting."
 authors = ["Sm00thix <oleemail@icloud.com>"]
 maintainers = ["Sm00thix <oleemail@icloud.com>"]

--- a/tests/naive_cvmatrix.py
+++ b/tests/naive_cvmatrix.py
@@ -52,7 +52,7 @@ class NaiveCVMatrix(CVMatrix):
     scale_Y : bool, optional, default=True
         Whether to scale `Y` before computation of
         :math:`\mathbf{X}^{\mathbf{T}}\mathbf{W}\mathbf{Y}` by dividing each row with
-        the row of `X`'s column-wise weighted standard deviations. The row of
+        the row of `Y`'s column-wise weighted standard deviations. The row of
         column-wise weighted standard deviations is computed on the training set for
         each fold to avoid data leakage. This parameter is ignored if `Y` is `None`.
 


### PR DESCRIPTION
Updated docstring for CVMatrix and NaiveCVMatrix to correctly state that scale_Y uses the standard deviation of Y. Before the docstring said that scale_Y would use the standard deviation of X to scale Y. Only the docstring was wrong. The implementation was correct.