### PR TITLE
Minor computational improvement and naming update

### DIFF
--- a/cvmatrix/__init__.py
+++ b/cvmatrix/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "3.1.0.post1"
+__version__ = "3.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cvmatrix"
-version = "3.1.0.post1"
+version = "3.1.1"
 description = "Fast computation of possibly weighted and possibly centered/scaled training set kernel matrices in a cross-validation setting."
 authors = ["Sm00thix <oleemail@icloud.com>"]
 maintainers = ["Sm00thix <oleemail@icloud.com>"]


### PR DESCRIPTION
Now computation of train_sum = sum_mat - sum_mat_val is done only once and shared across mean and std computations instead of being done for each. Also updated names from Xw and Yw to WX and WY.