### PR TITLE
API and doc update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2025
+### Changed
+- `CVMatrix` and `Partitioner` can now be imported with `from cvmatrix import CVMatrix, Partitioner` or `import cvmatrix` followed by `cvmatrix.CVMatrix` and `cvmatrix.Partitioner`.
+
 ## [3.0.0] - 2025
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The `cvmatrix` software package now also features **weigthed matrix produts** $\
 
 - Now you can import the class implementing all the algorithms with:
     ```python
-    from cvmatrix.cvmatrix import CVMatrix
+    from cvmatrix import CVMatrix
     ```
 
 ## Quick Start
@@ -42,8 +42,8 @@ The `cvmatrix` software package now also features **weigthed matrix produts** $\
 
 > ```python
 > import numpy as np
-> from cvmatrix.cvmatrix import CVMatrix
-> from cvmatrix.partitioner import Partitioner
+> from cvmatrix import CVMatrix
+> from cvmatrix import Partitioner
 >
 > N = 100  # Number of samples.
 > K = 50  # Number of features.

--- a/cvmatrix/__init__.py
+++ b/cvmatrix/__init__.py
@@ -1,1 +1,4 @@
-__version__ = "3.1.5"
+__version__ = "3.1.6"
+__all__ = ["CVMatrix", "Partitioner"]
+from .cvmatrix import CVMatrix
+from .partitioner import Partitioner

--- a/cvmatrix/cvmatrix.py
+++ b/cvmatrix/cvmatrix.py
@@ -17,7 +17,7 @@ from numpy import typing as npt
 
 
 class CVMatrix:
-    """
+    r"""
     Implements the fast cross-validation algorithms for kernel matrix-based models such
     as PCA, PCR, PLS, and OLS. The algorithms are based on Algorithms 2-7 and all the
     extensions in Table 1 in the paper by O.-C. G. Engstrøm and M. H. Jensen:
@@ -117,7 +117,7 @@ class CVMatrix:
         Y: Optional[npt.ArrayLike] = None,
         weights: Optional[npt.ArrayLike] = None,
     ) -> None:
-        """
+        r"""
         Loads and stores `X`, `Y`, and "weights", for cross-validation. Computes
         dataset-wide :math:`\mathbf{X}^{\mathbf{T}}\mathbf{W}\mathbf{X}` and, if `Y` is
         not `None`, :math:`\mathbf{X}^{\mathbf{T}}\mathbf{W}\mathbf{Y}`. If `center_X`,
@@ -239,7 +239,7 @@ class CVMatrix:
     ) -> Tuple[
         np.ndarray, Tuple[Optional[np.ndarray], Optional[np.ndarray], None, None]
     ]:
-        """
+        r"""
         Computes the training set :math:`\mathbf{X}^{\mathbf{T}}\mathbf{W}\mathbf{X}`
         corresponding to every sample except those at the `validation_indices`. Also
         computes the row of column-wise weighted means for `X` and the row of
@@ -300,7 +300,7 @@ class CVMatrix:
             Optional[np.ndarray],
         ],
     ]:
-        """
+        r"""
         Computes the training set :math:`\mathbf{X}^{\mathbf{T}}\mathbf{W}\mathbf{Y}`
         corresponding to every sample except those at the `validation_indices`. Also
         computes the row of column-wise weighted means for `X`, the row of column-wise
@@ -366,7 +366,7 @@ class CVMatrix:
             Optional[np.ndarray],
         ],
     ]:
-        """
+        r"""
         Computes the training set :math:`\mathbf{X}^{\mathbf{T}}\mathbf{W}\mathbf{X}`
         and :math:`\mathbf{X}^{\mathbf{T}}\mathbf{W}\mathbf{Y}` corresponding to every
         sample except those at the `validation_indices`. Also computes the row of
@@ -644,7 +644,7 @@ class CVMatrix:
             Optional[np.ndarray],
         ],
     ]:
-        """
+        r"""
         Returns the training set :math:`\mathbf{X}^{\mathbf{T}}\mathbf{W}\mathbf{X}`
         and/or :math:`\mathbf{X}^{\mathbf{T}}\mathbf{W}\mathbf{Y}` The training
         set corresponds to every sample except those at the `validation_indices`.
@@ -834,7 +834,7 @@ class CVMatrix:
         sum_w_train: Optional[np.floating] = None,
         center: bool = False,
     ) -> np.ndarray:
-        """
+        r"""
         Computes the training set kernel matrix for a given fold.
 
         Parameters
@@ -959,7 +959,7 @@ class CVMatrix:
         sum_w_train: np.floating,
         divisor: np.floating,
     ) -> np.ndarray:
-        """
+        r"""
         Computes the row of column-wise standard deviations of a matrix for a given
         fold.
 
@@ -1077,7 +1077,7 @@ class CVMatrix:
                 self.WY = self.Y * self.weights
 
     def _init_matrix_products(self) -> None:
-        """
+        r"""
         Initializes the global matrix products `XTX` and `XTY` for the
         entire dataset. These are :math:`\mathbf{X}^{\mathbf{T}}\mathbf{W}\mathbf{X}`
         and :math:`\mathbf{X}^{\mathbf{T}}\mathbf{W}\mathbf{Y}`, respectively.

--- a/examples/training_matrices.py
+++ b/examples/training_matrices.py
@@ -1,17 +1,16 @@
-"""
+r"""
 This file demonstrates how to use CVMatrix to compute training set matrices
 :math:`\mathbf{X}^{\mathbf{T}}\mathbf{X}` and
 :math:`\mathbf{X}^{\mathbf{T}}\mathbf{Y}` with possible centering and scaling of
 `X` and `Y` using training set means and standard deviations.
 
 Author: Ole-Christian Galbo Engstrøm
-E-mail: ole.e@di.ku.dk
+E-mail: ocge@foss.dk
 """
 
 import numpy as np
 
-from cvmatrix.cvmatrix import CVMatrix
-from cvmatrix.partitioner import Partitioner
+from cvmatrix import CVMatrix, Partitioner
 
 if __name__ == "__main__":
     # Create some example data. X must have shape (N, K) or (N,) and Y must have shape

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cvmatrix"
-version = "3.1.5"
+version = "3.1.6"
 description = "Fast computation of possibly weighted and possibly centered/scaled training set kernel matrices in a cross-validation setting."
 authors = ["Sm00thix <oleemail@icloud.com>"]
 maintainers = ["Sm00thix <oleemail@icloud.com>"]
@@ -25,8 +25,8 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.pytest.ini_options]
 addopts = [
-    "--typeguard-packages=ikpls",
-    "--cov=ikpls",
+    "--typeguard-packages=cvmatrix",
+    "--cov=cvmatrix",
     "--cov-report=xml",
     "--cov-report=html",
     "--cov-report=term-missing",

--- a/tests/naive_cvmatrix.py
+++ b/tests/naive_cvmatrix.py
@@ -19,7 +19,7 @@ from cvmatrix.cvmatrix import CVMatrix
 
 
 class NaiveCVMatrix(CVMatrix):
-    """
+    r"""
     Implements the naive cross-validation algorithms for kernel matrix-based models such
     as PCA, PCR, PLS, and OLS. The algorithms are described in detail in the paper by
     O.-C. G. Engstrøm and M. H. Jensen:


### PR DESCRIPTION
Made strings containing LaTeX r-strings to silence warning due to usage of "\m" e.g., in "\mathbf{X}".
Also added functionality to import cvmatrix.CVMatrix, cvmatrix.Partitioner or just cvmatrix.